### PR TITLE
Support for previewing diff using external commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ require("actions-preview").setup {
   diff = {
     ctxlen = 3,
   },
+
+  -- priority list of external command to highlight diff
+  -- disabled by defalt, must be set by yourself
+  highlight_command = {
+    -- require("actions-preview.highlight").delta(),
+    -- require("actions-preview.highlight").diff_so_fancy(),
+    -- require("actions-preview.highlight").diff_highlight(),
+  },
+
   -- priority list of preferred backend
   backend = { "telescope", "nui" },
 
@@ -103,6 +112,54 @@ require("actions-preview").setup {
     ignore_whitespace = true,
   },
   telescope = require("telescope.themes").get_dropdown { winblend = 10 },
+}
+```
+
+### `highlight_command`
+
+![actions-preview-delta](https://github.com/aznhe21/actions-preview.nvim/assets/2226696/edf18d6b-fb3c-4cb9-9c46-ce689278dc75)
+
+You can highlight diff with an external command by setting this item. This item
+is a priority list, which searches for available commands from the top.
+
+```lua
+local hl = require("actions-preview.highlight")
+require("actions-preview").setup {
+  highlight_command = {
+    -- Highlight diff using delta: https://github.com/dandavison/delta
+    -- The argument is optional, in which case "delta" is assumed to be
+    -- specified.
+    hl.delta("path/to/delta --option1 --option2"),
+    -- You may need to specify "--no-gitconfig" since it is dependent on
+    -- the gitconfig of the project by default.
+    -- hl.delta("delta --no-gitconfig --side-by-side"),
+
+    -- Highlight diff using diff-so-fancy: https://github.com/so-fancy/diff-so-fancy
+    -- The arguments are optional, in which case ("diff-so-fancy", "less -R")
+    -- is assumed to be specified. The existence of less is optional.
+    hl.diff_so_fancy("path/to/diff-so-fancy --option1 --option2"),
+
+    -- Highlight diff using diff-highlight included in git-contrib.
+    -- The arguments are optional; the first argument is assumed to be
+    -- "diff-highlight" and the second argument is assumed to be 
+    -- `{ colordiff = "colordiff", pager = "less -R" }`. The existence of
+    -- colordiff and less is optional.
+    hl.diff_highlight(
+      "path/to/diff-highlight",
+      { colordiff = "path/to/colordiff" }
+    ),
+
+    -- And, you can use any command to highlight diff.
+    -- Define the pipeline by `hl.commands`.
+    hl.commands({
+      { cmd = "command-to-diff-highlight" },
+      -- `optional` can be used to define that the command is optional.
+      { cmd = "less -R", optional = true },
+    }),
+    -- If you use optional `less -R` (or similar command), you can also use `hl.with_pager`.
+    hl.with_pager("command-to-diff-highlight"),
+    -- hl.with_pager("command-to-diff-highlight", "custom-pager"),
+  },
 }
 ```
 

--- a/lua/actions-preview/action.lua
+++ b/lua/actions-preview/action.lua
@@ -2,6 +2,51 @@ local config = require("actions-preview.config")
 
 local M = {}
 
+local Changes = {}
+M.Changes = Changes
+
+function Changes.new(changes)
+  return setmetatable({
+    changes = changes,
+  }, { __index = Changes })
+end
+
+function Changes:diff(opts)
+  opts = vim.tbl_extend("force", {
+    pseudo_args = "--code-actions",
+  }, opts or {})
+
+  local diff = ""
+  for _, change in ipairs(self.changes) do
+    -- imitate git diff
+    if change.kind == "rename" then
+      diff = diff .. string.format("diff %s a/%s b/%s\n", opts.pseudo_args, change.old_path, change.new_path)
+      diff = diff .. string.format("rename from %s\n", change.old_path)
+      diff = diff .. string.format("rename to %s\n", change.new_path)
+      diff = diff .. "\n"
+    elseif change.kind == "create" then
+      diff = diff .. string.format("diff %s a/%s b/%s\n", opts.pseudo_args, change.path, change.path)
+      -- delta needs file mode
+      diff = diff .. "new file mode 100644\n"
+      -- diff-so-fancy needs index
+      diff = diff .. "index 0000000..fffffff\n"
+      diff = diff .. "\n"
+    elseif change.kind == "delete" then
+      diff = diff .. string.format("diff %s a/%s b/%s\n", opts.pseudo_args, change.path, change.path)
+      diff = diff .. string.format("--- a/%s\n", change.path)
+      diff = diff .. "+++ /dev/null\n"
+      diff = diff .. "\n"
+    elseif change.kind == "edit" then
+      diff = diff .. string.format("diff %s a/%s b/%s\n", opts.pseudo_args, change.path, change.path)
+      diff = diff .. string.format("--- a/%s\n", change.path)
+      diff = diff .. string.format("+++ b/%s\n", change.path)
+      diff = diff .. vim.trim(vim.diff(change.old, change.new, config.diff)) .. "\n"
+      diff = diff .. "\n"
+    end
+  end
+  return diff
+end
+
 local function get_lines(bufnr)
   vim.fn.bufload(bufnr)
   return vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
@@ -29,84 +74,74 @@ local function apply_text_edits(text_edits, lines, offset_encoding)
   return new_lines
 end
 
-local function diff_text_edits(text_edits, bufnr, offset_encoding)
+local function edit_buffer_text(text_edits, bufnr, offset_encoding)
   local eol = get_eol(bufnr)
 
   local lines = get_lines(bufnr)
   local new_lines = apply_text_edits(text_edits, lines, offset_encoding)
-  return vim.diff(table.concat(lines, eol) .. eol, table.concat(new_lines, eol) .. eol, config.diff)
+  return table.concat(lines, eol) .. eol, table.concat(new_lines, eol) .. eol
 end
 
--- based on https://github.com/neovim/neovim/blob/v0.7.2/runtime/lua/vim/lsp/util.lua#L492-L523
-local function diff_text_document_edit(text_document_edit, offset_encoding)
-  local text_document = text_document_edit.textDocument
-  local bufnr = vim.uri_to_bufnr(text_document.uri)
+local function get_changes(workspace_edit, offset_encoding)
+  local changes = {}
 
-  return diff_text_edits(text_document_edit.edits, bufnr, offset_encoding)
-end
-
--- based on https://github.com/neovim/neovim/blob/v0.7.2/runtime/lua/vim/lsp/util.lua#L717-L756
-local function diff_workspace_edit(workspace_edit, offset_encoding)
-  local diff = ""
   if workspace_edit.documentChanges then
     for _, change in ipairs(workspace_edit.documentChanges) do
-      -- imitate git diff
       if change.kind == "rename" then
         local old_path = vim.fn.fnamemodify(vim.uri_to_fname(change.oldUri), ":.")
         local new_path = vim.fn.fnamemodify(vim.uri_to_fname(change.newUri), ":.")
 
-        diff = diff .. string.format("diff --code-actions a/%s b/%s\n", old_path, new_path)
-        diff = diff .. string.format("rename from %s\n", old_path)
-        diff = diff .. string.format("rename to %s\n", new_path)
-        diff = diff .. "\n"
+        table.insert(changes, {
+          kind = "rename",
+          old_path = old_path,
+          new_path = new_path,
+        })
       elseif change.kind == "create" then
         local path = vim.fn.fnamemodify(vim.uri_to_fname(change.uri), ":.")
 
-        diff = diff .. string.format("diff --code-actions a/%s b/%s\n", path, path)
-        diff = diff .. "new file\n"
-        diff = diff .. "\n"
+        table.insert(changes, {
+          kind = "create",
+          path = path,
+        })
       elseif change.kind == "delete" then
         local path = vim.fn.fnamemodify(vim.uri_to_fname(change.uri), ":.")
 
-        diff = diff .. string.format("diff --code-actions a/%s b/%s\n", path, path)
-        diff = diff .. string.format("--- a/%s\n", path)
-        diff = diff .. "+++ /dev/null\n"
-        diff = diff .. "\n"
+        table.insert(changes, {
+          kind = "delete",
+          path = path,
+        })
       elseif change.kind then
         -- do nothing
       else
-        local path = vim.fn.fnamemodify(vim.uri_to_fname(change.textDocument.uri), ":.")
+        local uri = change.textDocument.uri
+        local path = vim.fn.fnamemodify(vim.uri_to_fname(uri), ":.")
+        local bufnr = vim.uri_to_bufnr(uri)
+        local old, new = edit_buffer_text(change.edits, bufnr, offset_encoding)
 
-        diff = diff .. string.format("diff --code-actions a/%s b/%s\n", path, path)
-        diff = diff .. string.format("--- a/%s\n", path)
-        diff = diff .. string.format("+++ b/%s\n", path)
-        diff = diff .. vim.trim(diff_text_document_edit(change, offset_encoding)) .. "\n"
-        diff = diff .. "\n"
+        table.insert(changes, {
+          kind = "edit",
+          path = path,
+          old = old,
+          new = new,
+        })
       end
     end
-
-    return diff
-  end
-
-  local all_changes = workspace_edit.changes
-  if all_changes and not vim.tbl_isempty(all_changes) then
-    for uri, changes in pairs(all_changes) do
+  elseif workspace_edit.changes and not vim.tbl_isempty(workspace_edit.changes) then
+    for uri, edits in pairs(workspace_edit.changes) do
       local path = vim.fn.fnamemodify(vim.uri_to_fname(uri), ":.")
       local bufnr = vim.uri_to_bufnr(uri)
+      local old, new = edit_buffer_text(edits, bufnr, offset_encoding)
 
-      diff = diff
-        .. table.concat({
-          string.format("diff --code-actions a/%s b/%s", path, path),
-          string.format("--- a/%s", path),
-          string.format("+++ b/%s", path),
-          vim.trim(diff_text_edits(changes, bufnr, offset_encoding)),
-          "",
-          "",
-        }, "\n")
+      table.insert(changes, {
+        kind = "edit",
+        path = path,
+        old = old,
+        new = new,
+      })
     end
   end
 
-  return diff
+  return next(changes) and Changes.new(changes) or nil
 end
 
 local Action = {}
@@ -171,11 +206,14 @@ function Action:preview(callback)
   self:resolve(function(action)
     local client = vim.lsp.get_client_by_id(self.client_id)
 
-    local diff = action.edit and diff_workspace_edit(action.edit, client.offset_encoding)
-    if diff ~= nil and diff ~= "" then
-      self.previewed = {
+    local changes = action.edit and get_changes(action.edit, client.offset_encoding)
+    if changes then
+      local hl_cmd = config.get_highlight_command()
+      self.previewed = hl_cmd and {
+        cmdline = hl_cmd.make_cmdline(changes),
+      } or {
         syntax = "diff",
-        text = diff,
+        text = changes:diff(),
       }
     elseif action.command then
       local command = type(action.command) == "table" and action.command or action

--- a/lua/actions-preview/action.lua
+++ b/lua/actions-preview/action.lua
@@ -177,7 +177,6 @@ function Action:preview(callback)
         syntax = "diff",
         text = diff,
       }
-      callback(self.previewed)
     elseif action.command then
       local command = type(action.command) == "table" and action.command or action
       self.previewed = {

--- a/lua/actions-preview/backend/nui.lua
+++ b/lua/actions-preview/backend/nui.lua
@@ -1,5 +1,9 @@
 local M = {}
 
+local job_is_running = function(job_id)
+  return vim.fn.jobwait({ job_id }, 0)[1] == -1
+end
+
 function M.is_supported()
   local ok, _ = pcall(require, "nui.menu")
   return ok
@@ -10,16 +14,30 @@ function M.select(config, actions)
   local Menu = require("nui.menu")
   local Popup = require("nui.popup")
 
-  local nui_preview = Popup(vim.tbl_deep_extend("force", config.preview, {
-    size = nil,
-    border = {
-      text = {
-        top = "Code Action Preview",
+  local create_popup = function()
+    return Popup(vim.tbl_deep_extend("force", config.preview, {
+      size = nil,
+      border = {
+        text = {
+          top = "Code Action Preview",
+        },
       },
-    },
-  }))
+    }))
+  end
+  local create_layout_box = function(popup, select)
+    return Layout.Box({
+      Layout.Box(popup, { size = config.preview.size }),
+      Layout.Box(select, { size = config.select.size }),
+    }, { dir = config.dir })
+  end
 
+  local term_ids = {}
+
+  local nui_preview_blank = create_popup()
+  local nui_popups = {}
   local nui_select
+  local nui_layout
+
   nui_select = Menu(
     vim.tbl_deep_extend("force", config.select, {
       position = 0,
@@ -36,33 +54,55 @@ function M.select(config, actions)
       end, actions),
       keymap = config.keymap,
       on_change = function(item)
+        local popup = nui_popups[item.index]
+        if not popup then
+          popup = create_popup()
+          nui_popups[item] = popup
+        end
+
+        nui_layout:update(create_layout_box(popup, nui_select))
+
         item.action:preview(function(preview)
-          if nui_preview.bufnr == nil then
+          if popup.bufnr == nil then
             return
           end
 
-          preview = preview or { syntax = "", text = "preview not available" }
+          if preview and preview.cmdline then
+            if not term_ids[popup.bufnr] then
+              vim.api.nvim_buf_call(popup.bufnr, function()
+                term_ids[popup.bufnr] = vim.fn.termopen(preview.cmdline)
+              end)
+            end
+          else
+            preview = preview or { syntax = "", text = "preview not available" }
 
-          vim.api.nvim_buf_set_option(nui_preview.bufnr, "modifiable", true)
-          vim.api.nvim_buf_set_lines(nui_preview.bufnr, 0, -1, false, vim.split(preview.text, "\n", true))
-          vim.api.nvim_buf_set_option(nui_preview.bufnr, "syntax", preview.syntax)
-          vim.api.nvim_buf_set_option(nui_preview.bufnr, "modifiable", false)
+            vim.api.nvim_buf_set_lines(popup.bufnr, 0, -1, false, vim.split(preview.text, "\n", true))
+            vim.api.nvim_buf_set_option(popup.bufnr, "syntax", preview.syntax)
+            vim.api.nvim_buf_set_option(popup.bufnr, "modifiable", false)
+          end
         end)
       end,
       on_submit = function(item)
         item.action:apply()
       end,
+      on_close = function()
+        for _, term_id in pairs(term_ids) do
+          if job_is_running(term_id) then
+            vim.fn.jobstop(term_id)
+          end
+        end
+
+        nui_preview_blank:unmount()
+        for _, popup in ipairs(nui_popups) do
+          popup:unmount()
+        end
+        nui_select:unmount()
+      end,
     }
   )
 
-  local layout = Layout(
-    config.layout,
-    Layout.Box({
-      Layout.Box(nui_preview, { size = config.preview.size }),
-      Layout.Box(nui_select, { size = config.select.size }),
-    }, { dir = config.dir })
-  )
-  layout:mount()
+  nui_layout = Layout(config.layout, create_layout_box(nui_preview_blank, nui_select))
+  nui_layout:mount()
 end
 
 return M

--- a/lua/actions-preview/config.lua
+++ b/lua/actions-preview/config.lua
@@ -32,6 +32,11 @@ local default_config = {
   diff = {
     ctxlen = 3,
   },
+  highlight_command = {
+    -- hl.delta(),
+    -- hl.diff_so_fancy(),
+    -- hl.diff_highlight(),
+  },
 }
 local unmodifiable_config = {
   diff = {
@@ -46,6 +51,14 @@ function M.setup(opts)
   local config = vim.tbl_deep_extend("force", default_config, opts or {}, unmodifiable_config)
   for k, v in pairs(config) do
     M[k] = v
+  end
+end
+
+function M.get_highlight_command()
+  for _, cmd in ipairs(M.highlight_command) do
+    if cmd.is_available() then
+      return cmd
+    end
   end
 end
 

--- a/lua/actions-preview/highlight.lua
+++ b/lua/actions-preview/highlight.lua
@@ -1,0 +1,57 @@
+local M = {}
+
+function M.commands(commands)
+  return {
+    is_available = function()
+      for _, cmd in ipairs(commands) do
+        if cmd.optional ~= true and vim.fn.executable(cmd.cmd:match("^%S+")) ~= 1 then
+          return false
+        end
+      end
+      return true
+    end,
+    make_cmdline = function(changes)
+      local cmdline = string.format("echo %s", vim.fn.shellescape(changes:diff()))
+      for _, cmd in ipairs(commands) do
+        if vim.fn.executable(cmd.cmd:match("^%S+")) == 1 then
+          cmdline = cmdline .. " | " .. cmd.cmd
+        end
+      end
+      return cmdline
+    end,
+  }
+end
+
+function M.with_pager(cmd, pager)
+  pager = pager or "less -R"
+  return M.commands({ { cmd = cmd }, { cmd = pager, optional = true } })
+end
+
+function M.delta(cmd)
+  cmd = cmd or "delta"
+  return {
+    is_available = function()
+      return vim.fn.executable(cmd:match("^%S+")) == 1
+    end,
+    make_cmdline = function(changes)
+      return string.format("echo %s | %s", vim.fn.shellescape(changes:diff({ pseudo_args = "--git" })), cmd)
+    end,
+  }
+end
+
+function M.diff_so_fancy(cmd, pager)
+  cmd = cmd or "diff-so-fancy"
+  return M.with_pager(cmd, pager)
+end
+
+function M.diff_highlight(cmd, opts)
+  cmd = cmd or "diff-highlight"
+  opts = opts or {}
+  return M.commands({
+    { cmd = opts.colordiff or "colordiff", optional = true },
+    { cmd = cmd },
+    { cmd = opts.pager or "less -R", optional = true },
+  })
+end
+
+return M


### PR DESCRIPTION
![actions-preview-delta](https://github.com/aznhe21/actions-preview.nvim/assets/2226696/edf18d6b-fb3c-4cb9-9c46-ce689278dc75)

This PR adds previewing of diff using external commands with it disabled by default. You can enable the feature with a setting like this.

```lua
local hl = require("actions-preview.highlight")
require("actions-preview").setup {
  highlight_command = {
    hl.delta("delta --no-gitconfig --side-by-side"),
  },
}
```

Close #22.