### PR TITLE
fix: error occurs when disabling preview in telescope backend

### DIFF
--- a/lua/actions-preview/backend/telescope.lua
+++ b/lua/actions-preview/backend/telescope.lua
@@ -97,6 +97,10 @@ function M.select(config, acts)
           return {}
         end,
         teardown = function(self)
+          if not self.state then
+            return
+          end
+
           self.state.winid = nil
           self.state.bufnr = nil
 


### PR DESCRIPTION
When using telescope and preview was disabled in the settings, an error occurred and the list could not be closed. This is a regression of #26.

Partially addressed to #28.