### PR TITLE
Fix issues with closing menu in nui backend

### DIFF
--- a/lua/actions-preview/backend/nui.lua
+++ b/lua/actions-preview/backend/nui.lua
@@ -40,6 +40,11 @@ function M.select(config, actions)
 
   local focus_win = vim.api.nvim_get_current_win()
 
+  local lines = {}
+  for idx, action in ipairs(actions) do
+    table.insert(lines, Menu.item(action:title(), { index = idx, action = action }))
+  end
+
   nui_select = Menu(
     vim.tbl_deep_extend("force", config.select, {
       position = 0,
@@ -51,15 +56,13 @@ function M.select(config, actions)
       },
     }),
     {
-      lines = vim.tbl_map(function(action)
-        return Menu.item(action:title(), { action = action })
-      end, actions),
+      lines = lines,
       keymap = config.keymap,
       on_change = function(item)
         local popup = nui_popups[item.index]
         if not popup then
           popup = create_popup()
-          nui_popups[item] = popup
+          nui_popups[item.index] = popup
         end
 
         nui_layout:update(create_layout_box(popup, nui_select))

--- a/lua/actions-preview/backend/nui.lua
+++ b/lua/actions-preview/backend/nui.lua
@@ -103,8 +103,8 @@ function M.select(config, actions)
         end)
       end,
       on_submit = function(item)
-        item.action:apply()
         cleanup()
+        item.action:apply()
       end,
       on_close = cleanup,
     }

--- a/lua/actions-preview/backend/nui.lua
+++ b/lua/actions-preview/backend/nui.lua
@@ -39,6 +39,21 @@ function M.select(config, actions)
   local nui_layout
 
   local focus_win = vim.api.nvim_get_current_win()
+  local cleanup = function()
+    for _, term_id in pairs(term_ids) do
+      if job_is_running(term_id) then
+        vim.fn.jobstop(term_id)
+      end
+    end
+
+    nui_preview_blank:unmount()
+    for _, popup in ipairs(nui_popups) do
+      popup:unmount()
+    end
+    nui_select:unmount()
+
+    vim.api.nvim_set_current_win(focus_win)
+  end
 
   local lines = {}
   for idx, action in ipairs(actions) do
@@ -89,23 +104,9 @@ function M.select(config, actions)
       end,
       on_submit = function(item)
         item.action:apply()
-        vim.api.nvim_set_current_win(focus_win)
+        cleanup()
       end,
-      on_close = function()
-        for _, term_id in pairs(term_ids) do
-          if job_is_running(term_id) then
-            vim.fn.jobstop(term_id)
-          end
-        end
-
-        nui_preview_blank:unmount()
-        for _, popup in ipairs(nui_popups) do
-          popup:unmount()
-        end
-        nui_select:unmount()
-
-        vim.api.nvim_set_current_win(focus_win)
-      end,
+      on_close = cleanup,
     }
   )
 


### PR DESCRIPTION
This PR fixes these issues:

- Popups are created each time an item is selected.
- Buffers and processes remain after closing the menu. This was reported in #33.
- Cursor shifts after submit.
