### PR TITLE
fix: `Buffer is not 'modifiable'` in nui backend

### DIFF
--- a/lua/actions-preview/backend/nui.lua
+++ b/lua/actions-preview/backend/nui.lua
@@ -96,6 +96,7 @@ function M.select(config, actions)
           else
             preview = preview or { syntax = "", text = "preview not available" }
 
+            vim.api.nvim_buf_set_option(popup.bufnr, "modifiable", true)
             vim.api.nvim_buf_set_lines(popup.bufnr, 0, -1, false, vim.split(preview.text, "\n", true))
             vim.api.nvim_buf_set_option(popup.bufnr, "syntax", preview.syntax)
             vim.api.nvim_buf_set_option(popup.bufnr, "modifiable", false)


### PR DESCRIPTION
Fix regression in #36.

Happens when `highlight_command` is not used.