### PR TITLE
fix: line endings in non-LF files

### DIFF
--- a/lua/actions-preview/backend/nui.lua
+++ b/lua/actions-preview/backend/nui.lua
@@ -94,10 +94,10 @@ function M.select(config, actions)
               end)
             end
           else
-            preview = preview or { syntax = "", text = "preview not available" }
+            preview = preview or { syntax = "", lines = { "preview not available" } }
 
             vim.api.nvim_buf_set_option(popup.bufnr, "modifiable", true)
-            vim.api.nvim_buf_set_lines(popup.bufnr, 0, -1, false, vim.split(preview.text, "\n", true))
+            vim.api.nvim_buf_set_lines(popup.bufnr, 0, -1, false, preview.lines)
             vim.api.nvim_buf_set_option(popup.bufnr, "syntax", preview.syntax)
             vim.api.nvim_buf_set_option(popup.bufnr, "modifiable", false)
           end

--- a/lua/actions-preview/backend/telescope.lua
+++ b/lua/actions-preview/backend/telescope.lua
@@ -145,9 +145,9 @@ function M.select(config, acts)
                   term_ids[bufnr] = vim.fn.termopen(preview.cmdline)
                 end)
               else
-                preview = preview or { syntax = "", text = "preview not available" }
+                preview = preview or { syntax = "", lines = { "preview not available" } }
 
-                vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, vim.split(preview.text, "\n", true))
+                vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, preview.lines)
                 putils.highlighter(bufnr, preview.syntax, opts)
               end
             end)

--- a/lua/actions-preview/highlight.lua
+++ b/lua/actions-preview/highlight.lua
@@ -11,7 +11,8 @@ function M.commands(commands)
       return true
     end,
     make_cmdline = function(changes)
-      local cmdline = string.format("echo %s", vim.fn.shellescape(changes:diff()))
+      local diff = table.concat(changes:diff(), "\n")
+      local cmdline = string.format("echo %s", vim.fn.shellescape(diff))
       for _, cmd in ipairs(commands) do
         if vim.fn.executable(cmd.cmd:match("^%S+")) == 1 then
           cmdline = cmdline .. " | " .. cmd.cmd
@@ -34,7 +35,8 @@ function M.delta(cmd)
       return vim.fn.executable(cmd:match("^%S+")) == 1
     end,
     make_cmdline = function(changes)
-      return string.format("echo %s | %s", vim.fn.shellescape(changes:diff({ pseudo_args = "--git" })), cmd)
+      local diff = table.concat(changes:diff({ pseudo_args = "--git" }), "\n")
+      return string.format("echo %s | %s", vim.fn.shellescape(diff), cmd)
     end,
   }
 end


### PR DESCRIPTION
This PR fixes the display of escape sequences at the end of lines when `fileformat=dos` or `fileformat=mac`.

Close #35.