### PR TITLE
fix: may not work with neovim 0.10

### DIFF
--- a/lua/actions-preview/init.lua
+++ b/lua/actions-preview/init.lua
@@ -4,6 +4,38 @@ local Action = require("actions-preview.action").Action
 
 local M = {}
 
+-- based on https://github.com/neovim/neovim/blob/v0.10.0/runtime/lua/vim/lsp.lua#L735-L780
+local function lsp_get_clients(filter)
+  if vim.lsp.get_clients then
+    return vim.lsp.get_clients(filter)
+  end
+
+  vim.validate({ filter = { filter, "t", true } })
+
+  filter = filter or {}
+
+  local clients = {}
+
+  local bufnr = filter.bufnr
+  if bufnr == nil or bufnr == 0 then
+    bufnr = vim.api.nvim_get_current_buf()
+  end
+
+  for _, client in ipairs(vim.lsp.get_active_clients()) do
+    if
+      true
+      and (filter.id == nil or client.id == filter.id)
+      and (filter.bufnr == nil or client.attached_buffers[bufnr])
+      and (filter.name == nil or client.name == filter.name)
+      and (filter.method == nil or client.supports_method(filter.method))
+    then
+      clients[#clients + 1] = client
+    end
+  end
+
+  return clients
+end
+
 -- based on https://github.com/neovim/neovim/blob/v0.8.0/runtime/lua/vim/lsp/buf.lua#L153-L178
 ---@private
 ---@param bufnr integer
@@ -41,11 +73,41 @@ local function range_from_selection(bufnr, mode)
   }
 end
 
-local function on_code_action_results(results, ctx, options)
+local function on_code_action_results(results, opts)
+  -- based on https://github.com/neovim/neovim/blob/v0.10.0/runtime/lua/vim/lsp/buf.lua#L705-L731
+  local function action_filter(a)
+    -- filter by specified action kind
+    if opts and opts.context and opts.context.only then
+      if not a.kind then
+        return false
+      end
+      local found = false
+      for _, o in ipairs(opts.context.only) do
+        -- action kinds are hierarchical with . as a separator: when requesting only 'type-annotate'
+        -- this filter allows both 'type-annotate' and 'type-annotate.foo', for example
+        if a.kind == o or vim.startswith(a.kind, o .. ".") then
+          found = true
+          break
+        end
+      end
+      if not found then
+        return false
+      end
+    end
+    -- filter by user function
+    if opts and opts.filter and not opts.filter(a) then
+      return false
+    end
+    -- no filter removed this action
+    return true
+  end
+
   local actions = {}
-  for client_id, result in pairs(results) do
+  for _, result in pairs(results) do
     for _, action in pairs(result.result or {}) do
-      table.insert(actions, Action.new(ctx, client_id, action))
+      if action_filter(action) then
+        table.insert(actions, Action.new(result.ctx, action))
+      end
     end
   end
   if #actions == 0 then
@@ -53,74 +115,85 @@ local function on_code_action_results(results, ctx, options)
     return
   end
 
-  if options.apply and #actions == 1 then
+  if opts and opts.apply and #actions == 1 then
     actions[1]:apply()
     return
   end
   backend.select(config, actions)
 end
 
-local function code_action_request(params, options)
-  local bufnr = vim.api.nvim_get_current_buf()
-  local method = "textDocument/codeAction"
-  vim.lsp.buf_request_all(bufnr, method, params, function(results)
-    on_code_action_results(results, { bufnr = bufnr, method = method, params = params }, options)
-  end)
-end
-
 function M.setup(opts)
   config.setup(opts)
 end
 
--- based on https://github.com/neovim/neovim/blob/v0.8.0/runtime/lua/vim/lsp/buf.lua#L890-L944
+-- based on https://github.com/neovim/neovim/blob/v0.10.0/runtime/lua/vim/lsp/buf.lua#L824-L891
 --- Selects a code action available at the current
 --- cursor position.
 ---
----@param options table|nil Optional table which holds the following optional fields:
----  - context: (table|nil)
----      Corresponds to `CodeActionContext` of the LSP specification:
----        - diagnostics (table|nil):
----                      LSP `Diagnostic[]`. Inferred from the current
----                      position if not provided.
----        - only (table|nil):
----               List of LSP `CodeActionKind`s used to filter the code actions.
----               Most language servers support values like `refactor`
----               or `quickfix`.
----        - triggerKind (integer|nil):
----               The reason why code actions were requested.
----  - range: (table|nil)
----           Range for which code actions should be requested.
----           If in visual mode this defaults to the active selection.
----           Table must contain `start` and `end` keys with {row, col} tuples
----           using mark-like indexing. See |api-indexing|
----  - apply: (boolean|nil)
----           When set to `true`, and there is just one remaining action (after filtering),
----           the action is applied without user query.
----
+-- ---@param opts? vim.lsp.buf.code_action.Opts
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_codeAction
-function M.code_actions(options)
-  vim.validate({ options = { options, "t", true } })
-  options = options or {}
-  local context = options.context or {}
+---@see vim.lsp.protocol.CodeActionTriggerKind
+function M.code_actions(opts)
+  vim.validate({ options = { opts, "t", true } })
+  opts = opts or {}
+  -- Detect old API call code_action(context) which should now be
+  -- code_action({ context = context} )
+  --- @diagnostic disable-next-line:undefined-field
+  if opts.diagnostics or opts.only then
+    opts = { options = opts }
+  end
+  local context = opts.context or {}
+  if not context.triggerKind and vim.lsp.protocol.CodeActionTriggerKind then
+    context.triggerKind = vim.lsp.protocol.CodeActionTriggerKind.Invoked
+  end
   if not context.diagnostics then
     local bufnr = vim.api.nvim_get_current_buf()
     context.diagnostics = vim.lsp.diagnostic.get_line_diagnostics(bufnr)
   end
-  local params
   local mode = vim.api.nvim_get_mode().mode
-  if options.range then
-    assert(type(options.range) == "table", "code_action range must be a table")
-    local start = assert(options.range.start, "range must have a `start` property")
-    local end_ = assert(options.range["end"], "range must have a `end` property")
-    params = vim.lsp.util.make_given_range_params(start, end_)
-  elseif mode == "v" or mode == "V" then
-    local range = range_from_selection(0, mode)
-    params = vim.lsp.util.make_given_range_params(range.start, range["end"])
-  else
-    params = vim.lsp.util.make_range_params()
+  local bufnr = vim.api.nvim_get_current_buf()
+  local win = vim.api.nvim_get_current_win()
+  local clients = lsp_get_clients({ bufnr = bufnr, method = "textDocument/codeAction" })
+  local remaining = #clients
+  if remaining == 0 then
+    if next(lsp_get_clients({ bufnr = bufnr })) then
+      vim.notify("code action is not supported by the server", vim.log.levels.WARN)
+    end
+    return
   end
-  params.context = context
-  code_action_request(params, options)
+
+  -- ---@type table<integer, vim.lsp.CodeActionResultEntry>
+  local results = {}
+
+  -- ---@param err? lsp.ResponseError
+  -- ---@param result? (lsp.Command|lsp.CodeAction)[]
+  -- ---@param ctx lsp.HandlerContext
+  local function on_result(err, result, ctx)
+    results[ctx.client_id] = { error = err, result = result, ctx = ctx }
+    remaining = remaining - 1
+    if remaining == 0 then
+      on_code_action_results(results, opts)
+    end
+  end
+
+  for _, client in ipairs(clients) do
+    -- ---@type lsp.CodeActionParams
+    local params
+    if opts.range then
+      assert(type(opts.range) == "table", "code_action range must be a table")
+      local start = assert(opts.range.start, "range must have a `start` property")
+      local end_ = assert(opts.range["end"], "range must have a `end` property")
+      params = vim.lsp.util.make_given_range_params(start, end_, bufnr, client.offset_encoding)
+    elseif mode == "v" or mode == "V" then
+      local range = range_from_selection(bufnr, mode)
+      params =
+        vim.lsp.util.make_given_range_params(range.start, range["end"], bufnr, client.offset_encoding)
+    else
+      params = vim.lsp.util.make_range_params(win, client.offset_encoding)
+    end
+    params.context = context
+    client.request("textDocument/codeAction", params, on_result, bufnr)
+  end
 end
 
 return M


### PR DESCRIPTION
This PR fixes the plugin not working properly with some LSPs in neovim 0.10.

The plugin will still work with versions older than neovim 0.10 (0.7 or later as far as I have lightly tested).

Close #50.