### PR TITLE
Added mini.pick backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ A neovim plugin that preview code with LSP code actions applied.
 
 The following backends are available:
 - [telescope.nvim]
+- [mini.pick]
 - [nui.nvim]
 
 [telescope.nvim]: https://github.com/nvim-telescope/telescope.nvim
+[mini.pick]: https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-pick.md
 [nui.nvim]: https://github.com/MunifTanjim/nui.nvim
 
 ## Installation
@@ -46,7 +48,7 @@ require("actions-preview").setup {
   },
 
   -- priority list of preferred backend
-  backend = { "telescope", "nui" },
+  backend = { "telescope", "minipick", "nui" },
 
   -- options related to telescope.nvim
   telescope = vim.tbl_extend(

--- a/lua/actions-preview/backend/minipick.lua
+++ b/lua/actions-preview/backend/minipick.lua
@@ -1,0 +1,76 @@
+local M = {}
+
+local job_is_running = function(job_id)
+  return vim.fn.jobwait({ job_id }, 0)[1] == -1
+end
+
+function M.is_supported()
+  local ok, _ = pcall(require, "mini.pick")
+  return ok
+end
+
+function M.select(config, actions)
+  local minipick = require("mini.pick")
+
+  local buffers = {}
+  local term_ids = {}
+
+  local cleanup = function()
+    for _, buf_id in ipairs(buffers) do
+      local term_id = term_ids[buf_id]
+      if term_id and job_is_running(term_id) then
+        vim.fn.jobstop(term_id)
+      end
+      if vim.api.nvim_buf_is_valid(buf_id) then
+        vim.api.nvim_buf_delete(buf_id, { force = true })
+      end
+    end
+  end
+
+  local preview_action = function(buf_id, item)
+    table.insert(buffers, buf_id)
+
+    item.action:preview(function(preview)
+      if preview and preview.cmdline then
+        vim.api.nvim_buf_call(buf_id, function()
+          term_ids[buf_id] = vim.pn.termopen(preview.cmdline)
+        end)
+      else
+        preview = preview or { syntax = "", lines = { "preview not available" } }
+
+        vim.api.nvim_buf_set_lines(buf_id, 0, -1, false, preview.lines)
+        if preview.syntax ~= "" then
+          vim.treesitter.start(buf_id, preview.syntax)
+        else
+          vim.api.nvim_set_option_value("syntax", preview.syntax, { buf = buf_id })
+        end
+
+        vim.api.nvim_set_option_value("modifiable", false, { buf = buf_id })
+      end
+    end)
+  end
+
+  local choose_action = function(item)
+    cleanup()
+    item.action:apply()
+  end
+
+  local source = {
+    name = "Code Actions",
+    items = {},
+    preview = preview_action,
+    choose = choose_action,
+  }
+
+  for idx, action in ipairs(actions) do
+    table.insert(source.items, {
+      text = action:title(),
+      idx = idx,
+      action = action,
+    })
+  end
+
+  minipick.start({ source = source })
+end
+
+return M

--- a/lua/actions-preview/config.lua
+++ b/lua/actions-preview/config.lua
@@ -1,5 +1,5 @@
 local default_config = {
-  backend = { "telescope", "nui" },
+  backend = { "telescope", "minipick", "nui" },
   telescope = nil,
   nui = {
     dir = "col",


### PR DESCRIPTION
I've recently started using [mini.pick](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-pick.md) and thought I'd give a shot at adding it as a backend to actions-preview. I mainly just adapted what code was already there for telescope and nui. This is my first time contributing to this repo and writing code for mini.pick, so I hope it's satisfactory. Please let me know if any changes are needed!

> Note: mini.pick has built-in caching support, so I didn't attempt to copy the caching stuff that the nui backend has.

> I _believe_ this cleans up after itself properly. I didn't thoroughly test that out though. I can if you need me to.

> The only issue I've run into is when you do a preview and it hits the code branch where it spits out a hardcoded "preview not available", hitting tab to return to the picker closes the picker. In every other case that I've tested, it works as intended.