### PR TITLE
feat: allow functions to be specified in `highlight_command`

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,12 @@ require("actions-preview").setup {
     -- If you use optional `less -R` (or similar command), you can also use `hl.with_pager`.
     hl.with_pager("command-to-diff-highlight"),
     -- hl.with_pager("command-to-diff-highlight", "custom-pager"),
+
+    -- Functions can also be specified for items. Functions are executed during setup.
+    -- This is useful for `require(...)` at definition time, such as in lazy.nvim.
+    function()
+        return require("actions-preview.highlight").delta()
+    end,
   },
 }
 ```

--- a/lua/actions-preview/config.lua
+++ b/lua/actions-preview/config.lua
@@ -52,6 +52,12 @@ function M.setup(opts)
   for k, v in pairs(config) do
     M[k] = v
   end
+
+  for i, cmd in ipairs(M.highlight_command) do
+    if type(cmd) == "function" then
+      M.highlight_command[i] = cmd()
+    end
+  end
 end
 
 function M.get_highlight_command()


### PR DESCRIPTION
This PR will allow you to set `highlight_command` in lazy.nvim, etc. without any hacks.

Close #58.