### PR TITLE
feat(backend): add snacks picker support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@ The following backends are available:
 - [telescope.nvim]
 - [mini.pick]
 - [nui.nvim]
+- [snacks.nvim]
 
 [telescope.nvim]: https://github.com/nvim-telescope/telescope.nvim
 [mini.pick]: https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-pick.md
 [nui.nvim]: https://github.com/MunifTanjim/nui.nvim
+[snacks.nvim]: https://github.com/folke/snacks.nvim
 
 ## Installation
 
@@ -48,7 +50,7 @@ require("actions-preview").setup {
   },
 
   -- priority list of preferred backend
-  backend = { "telescope", "minipick", "nui" },
+  backend = { "telescope", "minipick", "snacks", "nui" },
 
   -- options related to telescope.nvim
   telescope = vim.tbl_extend(
@@ -101,6 +103,12 @@ require("actions-preview").setup {
         padding = { 0, 1 },
       },
     },
+  },
+
+  --- options for snacks picker
+  ---@type snacks.picker.Config
+  snacks = {
+    layout = { preset = "default" },
   },
 }
 ```

--- a/lua/actions-preview/backend/snacks.lua
+++ b/lua/actions-preview/backend/snacks.lua
@@ -1,0 +1,69 @@
+local M = {}
+
+--- function called to preview item
+--- taken from minipick backend
+---@type snacks.picker.preview
+local preview = function(ctx)
+  local item = ctx.item
+  local buf_id = ctx.preview:scratch()
+  item.action:preview(function(preview)
+    if preview and preview.cmdline then
+      vim.api.nvim_buf_call(buf_id, function()
+        vim.fn.termopen(preview.cmdline)
+      end)
+    else
+      preview = preview or { syntax = "", lines = { "preview not available" } }
+
+      vim.api.nvim_buf_set_lines(buf_id, 0, -1, false, preview.lines)
+      if preview.syntax ~= "" then
+        vim.treesitter.start(buf_id, preview.syntax)
+      else
+        vim.api.nvim_set_option_value("syntax", preview.syntax, { buf = buf_id })
+      end
+
+      vim.api.nvim_set_option_value("modifiable", false, { buf = buf_id })
+    end
+  end)
+end
+
+--- function called by picker when user selects item
+---@type snacks.picker.Action.spec
+local function confirm(picker, item)
+  picker:close()
+  item.action:apply()
+end
+
+--- map actions to snacks items
+---@param actions table
+---@return snacks.picker.finder.Item[]
+local function actions_to_items(actions)
+  ---@type snacks.picker.finder.Item[]
+  local items = {}
+  for _, action in ipairs(actions) do
+    local item = { text = action:title(), action = action }
+    table.insert(items, item)
+  end
+  return items
+end
+
+---@type snacks.picker.Config
+local basic_snacks_opts = {
+  title = "Code Actions",
+  items = {},
+  format = "text",
+  preview = preview,
+  confirm = confirm
+}
+
+function M.is_supported()
+  local ok, _ = pcall(require, "snacks.picker")
+  return ok
+end
+
+function M.select(config, actions)
+  local opts = vim.tbl_deep_extend('force', basic_snacks_opts, config or {})
+  opts.items = actions_to_items(actions)
+  require("snacks.picker").pick(nil, opts)
+end
+
+return M

--- a/lua/actions-preview/config.lua
+++ b/lua/actions-preview/config.lua
@@ -1,5 +1,5 @@
 local default_config = {
-  backend = { "telescope", "minipick", "nui" },
+  backend = { "telescope", "minipick", "snacks", "nui" },
   telescope = nil,
   nui = {
     dir = "col",
@@ -28,6 +28,10 @@ local default_config = {
         padding = { 0, 1 },
       },
     },
+  },
+  ---@type snacks.picker.Config
+  snacks = {
+    layout = { preset = "default" },
   },
   diff = {
     ctxlen = 3,


### PR DESCRIPTION
I have added support for [snacks.nvim picker](https://github.com/folke/snacks.nvim/blob/main/docs/picker.md).

- Supports custom picker configuration of `snacks.picker.Config` type
- I took `minipick.lua` as template
- I have tested it with delta diff