### PR TITLE
fix(snacks.lua): add buffer validity checks

### DIFF
--- a/lua/actions-preview/backend/snacks.lua
+++ b/lua/actions-preview/backend/snacks.lua
@@ -26,6 +26,11 @@ local preview = function(ctx)
   local item = ctx.item
   local buf_id = ctx.preview:scratch()
   item.action:preview(function(preview)
+    -- Add a check to ensure the buffer is still valid before operating on it
+    if not vim.api.nvim_buf_is_valid(buf_id) then
+      return
+    end
+
     if preview and preview.cmdline then
       vim.api.nvim_buf_call(buf_id, function()
         vim.fn.termopen(preview.cmdline)


### PR DESCRIPTION
Closes #65 

This pull request improves the robustness of the `preview` function in `lua/actions-preview/backend/snacks.lua` by introducing checks to ensure that the buffer being operated on is still valid. This prevents potential errors when the buffer becomes invalid during asynchronous operations.

### Buffer validity checks:

* Added `vim.api.nvim_buf_is_valid(buf_id)` checks before performing operations such as `termopen`, setting lines, and starting a syntax highlighter to ensure the buffer is still valid. This helps avoid runtime errors if the buffer is deleted or invalidated during asynchronous execution.

* Wrapped the `vim.api.nvim_set_option_value` call in a conditional block to ensure it is only executed if the buffer remains valid.