### PR TITLE
fix(telescope): add buffer validity checks

### DIFF
--- a/lua/actions-preview/backend/telescope.lua
+++ b/lua/actions-preview/backend/telescope.lua
@@ -147,6 +147,10 @@ function M.select(config, acts)
               else
                 preview = preview or { syntax = "", lines = { "preview not available" } }
 
+                if not vim.api.nvim_buf_is_valid(bufnr) then
+                  return
+                end
+                    
                 vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, preview.lines)
                 putils.highlighter(bufnr, preview.syntax, opts)
               end


### PR DESCRIPTION
お疲れ様です、

I'm using actions-preview with telescope and I recently noticed that it throws errors like this, while still working file. I've added a check to the telescope backend, similar to https://github.com/aznhe21/actions-preview.nvim/pull/66. It fixed the issue for me.

<img width="747" alt="Снимок экрана 2025-05-10 в 17 17 24" src="https://github.com/user-attachments/assets/749323b5-5e7a-4889-a26f-f814a6214910" />