### PR TITLE
Handle the case where the action wasn't resolved, but the error is also nil

### DIFF
--- a/lua/actions-preview/action.lua
+++ b/lua/actions-preview/action.lua
@@ -188,6 +188,8 @@ function Action:resolve(callback)
         vim.notify(err.code .. ": " .. err.message, vim.log.levels.ERROR)
       end
       self.resolved = self.action
+    elseif not resolved_action then
+      self.resolved = self.action
     else
       self.resolved = resolved_action
     end
@@ -202,10 +204,6 @@ function Action:preview(callback)
   end
 
   self:resolve(function(action)
-    if not action then
-      return
-    end
-      
     local client = vim.lsp.get_client_by_id(self.context.client_id)
 
     local changes = action.edit and get_changes(action.edit, client.offset_encoding)

--- a/lua/actions-preview/action.lua
+++ b/lua/actions-preview/action.lua
@@ -202,6 +202,10 @@ function Action:preview(callback)
   end
 
   self:resolve(function(action)
+    if not action then
+      return
+    end
+      
     local client = vim.lsp.get_client_by_id(self.context.client_id)
 
     local changes = action.edit and get_changes(action.edit, client.offset_encoding)


### PR DESCRIPTION
This is a similar issue. 

At some point, probably because of changes in typescript-tools.nvim or another LSP, I started getting cases where both resolved_action and err are nil. The code doesn't account for that case, so it crashes with an error. This PR adds a condition for this case.